### PR TITLE
vpc: bug fixes and implement vpcInstance.Stop()

### DIFF
--- a/backend/vpc.go
+++ b/backend/vpc.go
@@ -211,6 +211,7 @@ func (p *vpcProvider) Start(ctx goctx.Context, _ *StartAttributes) (i Instance, 
 			logger.Info("cleaning up SSH key due to instance creation failure")
 			if _, err := p.service.DeleteKeyWithContext(ctx, &vpcv1.DeleteKeyOptions{ID: key.ID}); err != nil {
 				logger.WithError(err).Error("failed to cleanup SSH Key")
+				return
 			}
 			logger.Debug("cleaned up SSH key")
 		}
@@ -226,6 +227,7 @@ func (p *vpcProvider) Start(ctx goctx.Context, _ *StartAttributes) (i Instance, 
 			logger.Info("cleaning up instance due to failure")
 			if _, err := p.service.DeleteInstanceWithContext(ctx, &vpcv1.DeleteInstanceOptions{ID: instance.ID}); err != nil {
 				logger.WithError(err).Error("failed to cleanup instance")
+				return
 			}
 			logger.Debug("cleaned up instance")
 

--- a/backend/vpc.go
+++ b/backend/vpc.go
@@ -245,7 +245,6 @@ func (p *vpcProvider) Start(ctx goctx.Context, _ *StartAttributes) (i Instance, 
 
 func (p *vpcProvider) createSSHKey(ctx goctx.Context) (*vpcv1.Key, *ssh.AuthDialer, error) {
 	logger := context.LoggerFromContext(ctx).WithField("self", "backend/vpc")
-	hostname := hostnameFromContext(ctx)
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {
@@ -261,7 +260,6 @@ func (p *vpcProvider) createSSHKey(ctx goctx.Context) (*vpcv1.Key, *ssh.AuthDial
 	}
 
 	sshKeyOptions := &vpcv1.CreateKeyOptions{
-		Name:          &hostname,
 		ResourceGroup: &vpcv1.ResourceGroupIdentityByID{ID: &p.resourceGroupID},
 	}
 	sshKeyOptions.SetPublicKey(string(publicKey))
@@ -293,7 +291,6 @@ func (p *vpcProvider) createInstance(ctx goctx.Context, key *vpcv1.Key) (*vpcv1.
 
 func (p *vpcProvider) getInstancePrototype(ctx goctx.Context, key *vpcv1.Key) (*vpcv1.InstancePrototypeInstanceByImage, error) {
 	logger := context.LoggerFromContext(ctx).WithField("self", "backend/vpc")
-	hostname := hostnameFromContext(ctx)
 
 	// Choose random subnet to balance VMs. Ideally multiple subnets are given that
 	// are spread out across availability zones.
@@ -322,7 +319,6 @@ func (p *vpcProvider) getInstancePrototype(ctx goctx.Context, key *vpcv1.Key) (*
 	instancePrototype := &vpcv1.InstancePrototypeInstanceByImage{
 		Keys:          []vpcv1.KeyIdentityIntf{&vpcv1.KeyIdentityByID{ID: key.ID}},
 		Profile:       &vpcv1.InstanceProfileIdentityByName{Name: &p.instanceProfile},
-		Name:          &hostname,
 		ResourceGroup: &vpcv1.ResourceGroupIdentityByID{ID: &p.resourceGroupID},
 		UserData:      &userData,
 		VPC:           &vpcv1.VPCIdentityByID{ID: &p.vpcID},

--- a/backend/vpc.go
+++ b/backend/vpc.go
@@ -29,9 +29,9 @@ const (
 	defaultVPCRegion           = "us-south"
 	defaultVPCInstanceUsername = "travis"
 
-	defaultVPCAPIRetries       = 120
+	defaultVPCAPIRetries       = 60
 	defaultVPCAPIRetryInterval = time.Second * 5
-	defaultVPCSSHRetries       = 120
+	defaultVPCSSHRetries       = 60
 	defaultVPCSSHRetryInterval = time.Second * 2
 )
 

--- a/backend/vpc.go
+++ b/backend/vpc.go
@@ -236,14 +236,14 @@ func (p *vpcProvider) Start(ctx goctx.Context, _ *StartAttributes) (i Instance, 
 		}
 	}()
 
-	instance, err = p.waitForInstance(ctx, instance, sshDialer)
+	newInstance, err := p.waitForInstance(ctx, instance, sshDialer)
 	if err != nil {
 		return nil, err
 	}
 
 	return &vpcInstance{
 		provider:  p,
-		instance:  instance,
+		instance:  newInstance,
 		sshDialer: sshDialer,
 		sshKey:    key,
 		hostname:  hostname,


### PR DESCRIPTION
Suggest reviewing on a commit basis.

Main goal is to implement vpcInstance.Stop() which will clean up all the resources once a job is complete. There is some refactoring that goes around this to put common code into their own functions, particularly around anything that polls for a status.

There are also other bug fixes that I dug up in testing:
- d53c00d: Overwriting the `instance` variable like this could overwrite it with nil, causing the deferred functions to segfault.
- 00cfc60: Missing return value caused logs to report something was cleaned up when it actually wasn't.
- ebd5fe4: Too permissive of timeouts could cause the context to expire. When context expires, cleanup functions won't run since they operate under the same context.
- 51b0a5b: The Worker provided hostname is not necessarily unique. A requeued build may run with the same hostname. If this happens, AND resources weren't cleaned up (due to a worker dying) then the build will run into hostname collision issues. It would require someone to go in and delete the conflicting resources to unjam it. Instead, just let IBM Cloud generate the names.